### PR TITLE
Restore BackgroundGrid component in layout and rename History section…

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
           <body
             className={`${geistSans.variable} ${geistMono.variable} antialiased font-[family-name:var(--font-geist-sans)] transition-colors duration-300`}
           >
-            {/* <BackgroundGrid /> */}
+            <BackgroundGrid />
             <Header />
             <div className="">{children}</div>
           </body>

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -28,7 +28,7 @@ export default function History() {
   }, []);
   return (
     <section className={`p-4 max-w-4xl mx-auto`}>
-      <h1 className="text-2xl font-bold py-4">History</h1>
+      <h1 className="text-2xl font-bold py-4">Leaderboard</h1>
       <DataTable columns={user_columns} data={data} />
     </section>
   );


### PR DESCRIPTION
This pull request includes changes to improve the user interface and correct a component name in the application. The most important changes include re-enabling the `BackgroundGrid` component in the layout and updating a heading in the leaderboard page.

UI Improvements:

* [`app/layout.tsx`](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL37-R37): Re-enabled the `BackgroundGrid` component by uncommenting its line in the `body` section.

Component Naming Correction:

* [`app/leaderboard/page.tsx`](diffhunk://#diff-6aab0a50127f1bbf9d591020ac34c87b8483f74ce7cd9d505b5c4bdd6d463c0dL31-R31): Updated the heading from "History" to "Leaderboard" to accurately reflect the content of the page.… to Leaderboard in leaderboard page